### PR TITLE
Cards of color pickers

### DIFF
--- a/panel/app.py
+++ b/panel/app.py
@@ -138,6 +138,30 @@ def decomposition(dec_limit, si, inputs, output):
     )
 
 
+def base_colors(res):
+    all_colors = sd.palette(res.states)
+    colors = all_colors[:: res.states[0]]
+    colors = [mpl.colors.rgb2hex(color, keep_alpha=False) for color in colors]
+    return colors
+
+
+def update_colors_select(event):
+    colors = [color_picker.value for color_picker in color_pickers]
+    colors_select.param.update(
+        options=colors,
+        value=colors,
+    )
+
+
+def create_color_pickers(states, colors):
+    color_picker_list = []
+    for state, color in zip(states[0][::-1], colors):
+        color_picker = pn.widgets.ColorPicker(name=state, value=color)
+        color_picker.param.watch(update_colors_select, "value")
+        color_picker_list.append(color_picker)
+    color_pickers[:] = color_picker_list
+
+
 def palette(res, colors_picked):
     cmaps = [colormap_from_single_color(color_picked) for color_picked in colors_picked]
     return sd.palette(res.states, cmaps=cmaps)
@@ -282,46 +306,20 @@ interactive_states = pn.bind(
 )
 
 
-def base_colors(res):
-    all_colors = sd.palette(res.states)
-    colors = all_colors[:: res.states[0]]
-    colors = [mpl.colors.rgb2hex(color, keep_alpha=False) for color in colors]
-    return colors
-
-
 interactive_base_colors = pn.bind(base_colors, interactive_decomposition)
 
 
-def update_colors_select(event):
-    colors = [color_picker.value for color_picker in color_pickers]
-    colors_select.param.update(
-        options=colors,
-        value=colors,
-    )
-
-
-def create_color_pickers(states, colors):
-    color_picker_list = []
-    for state, color in zip(states[0], colors):
-        color_picker = pn.widgets.ColorPicker(name=state, value=color)
-        color_picker.param.watch(update_colors_select, "value")
-        color_picker_list.append(color_picker)
-    color_pickers[:] = color_picker_list
-
-
+color_pickers = pn.Card(title="Main color for states")
 colors_select = pn.widgets.MultiSelect(
     value=interactive_base_colors,
     options=interactive_base_colors,
     name="Colors",
-    visible=True,
+    visible=False,
 )
-color_pickers = pn.Card(title="Main color for states")
-# colors_select.param.update(
-#     value=['#fdb97d', '#c6c7e1', '#fca082'],
-#     options=['#fdb97d', '#c6c7e1', '#fca082'],
-# )
 
-pn.bind(create_color_pickers, interactive_states, colors_select.param.value, watch=True)
+dummy_color_pickers_bind = pn.bind(
+    create_color_pickers, interactive_states, colors_select.param.value, watch=True
+)
 
 interactive_palette = pn.bind(
     palette, interactive_decomposition, colors_select.param.value
@@ -359,7 +357,7 @@ pn_params = pn.layout.WidgetBox(
     pn.pane.Markdown("## Visualization", styles={"color": blue_color}),
     switch_histogram_boxplot,
     selector_n_bins,
-    colors_select,  # hidden
+    dummy_color_pickers_bind,
     color_pickers,
     # pn.Row(logout),
     max_width=350,

--- a/src/simdec/visualization.py
+++ b/src/simdec/visualization.py
@@ -94,9 +94,11 @@ def palette(
     if cmaps is None:
         cmaps = [mpl.colormaps[cmap] for cmap in SEQUENTIAL_PALETTES[:n_cmaps]]
     else:
+        cmaps = cmaps[:n_cmaps]
         if len(cmaps) != n_cmaps:
             raise ValueError(
-                "Must have the same number of cmaps as the number of first states"
+                f"Must have the same number of cmaps ({len(cmaps)}) as the "
+                f"number of first states ({n_cmaps})"
             )
 
     colors = []


### PR DESCRIPTION
One caveat is that by default the colormap is slightly changed. This is because I am calculating a colormap using a single color to get this working. The resulting colormap per group is a linear variation of the luminance channel.

@gnopik if you want to test a live version, I could make another testing deployment in the same project. I think if we do this, I would not link it to the domain (e.g. dev.simdec.io). I think I read that Cloud Run has issues with automatically handling subdomains. But I can always try and see.

This is how it looks:

<img width="600" alt="Screenshot 2023-10-17 at 11 21 52" src="https://github.com/Simulation-Decomposition/simdec-python/assets/23188539/9892d386-4891-494f-931e-629f633c93a8">
<img width="600" alt="Screenshot 2023-10-17 at 11 22 25" src="https://github.com/Simulation-Decomposition/simdec-python/assets/23188539/249b69ce-4706-4874-9925-ffaab644b41f">

