### PR TITLE
ci: migrate release pipeline to uv

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,19 +13,21 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           architecture: 'x64'
 
-      - name: Install hatch
-        run: pip install hatch
-
       - name: Build
-        run: hatch build
+        run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dev = [
     "simdec[doc,test,dashboard]",
     "watchfiles",
     "pre-commit",
-    "hatch",
 ]
 
 [project.urls]


### PR DESCRIPTION
Replaced hatch with uv in release.yaml and removed hatch from dev depencencies in pyproject.toml. Issue #48